### PR TITLE
Make includes relative to the `include` directory

### DIFF
--- a/include/HTML/Document.h
+++ b/include/HTML/Document.h
@@ -10,7 +10,7 @@
  */
 #pragma once
 
-#include "Element.h"
+#include "HTML/Element.h"
 
 #include <sstream>
 #include <string>

--- a/include/HTML/HTML.h
+++ b/include/HTML/HTML.h
@@ -15,5 +15,5 @@
  * @brief    A simple C++ header-only HTML Generator library, using a Document Object Model (DOM).
  */
 
-#include "Element.h"
-#include "Document.h"
+#include "HTML/Element.h"
+#include "HTML/Document.h"


### PR DESCRIPTION
This will make it easier to use the library from a build system such as Bazel.